### PR TITLE
docs: expand CLAUDE.md with architecture, conventions and tech stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,5 +79,12 @@ site/                 # Cloudflare Pages product website
 
 ## Important Notes
 
-- **Never commit** `.xcconfig` files containing API keys.
+- **Never commit** `.xcconfig` files or `.env` files containing API keys (e.g., Cloudflare, Apple notarization, Firebase, Stripe, third-party ML APIs). Add any local config files to `.gitignore`.
+- **Storing secrets**:
+  - **Local dev**: use environment variables, `.env` files (never committed), macOS Keychain, or [`envchain`](https://github.com/sorah/envchain) to inject secrets per-command. Example:
+    ```sh
+    envchain cloudflare sh -c 'OTEL_TRACES_EXPORTER= TF_VAR_cloudflare_api_token=$CLOUDFLARE_API_TOKEN TF_VAR_cloudflare_account_id=$CLOUDFLARE_ACCOUNT_ID terraform plan'
+    ```
+  - **CI**: use GitHub Actions secrets, HashiCorp Vault, or equivalent encrypted secret stores.
+  - **Naming convention**: prefix keys with `VIDPARE_` (e.g., `VIDPARE_CLOUDFLARE_API_TOKEN`, `VIDPARE_APPLE_API_KEY`).
 - The project uses a `Package.swift`-based layout — open the repo root in Xcode (`File > Open...`) for full IDE support including signing and entitlements.


### PR DESCRIPTION
## Summary

- Add tech stack section covering platform, UI framework, video layer, build system, and player details
- Replace WIP architecture placeholder with actual architecture diagram and project structure
- Add key technical conventions for export modes, supported formats, and AVFoundation gotchas
- Update development commands to match Package.swift-based workflow and add site commands

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm no sensitive information is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive developer documentation for the VidPare macOS video trimmer: tech stack, architecture, coding conventions, supported formats, export modes, and HEVC handling.
  * Described SwiftPM-based build and development workflow, site/build instructions, dependencies, and project structure.
  * Included guidance on asset/export behavior, progress polling, security, secrets management, and local vs CI configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->