### PR TITLE
fix(site): prevent Astro from inlining scripts, enforce CSP script-src 'self'

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -7,7 +7,8 @@ export default defineConfig({
   integrations: [tailwind(), sitemap()],
   vite: {
     build: {
-      target: 'es2022'
+      target: 'es2022',
+      assetsInlineLimit: 0
     }
   }
 });


### PR DESCRIPTION
Set assetsInlineLimit to 0 in Vite build config to force all scripts to be external files. This resolves CSP violations where Astro was inlining small scripts like the reveal animation handler. External scripts now comply with the script-src 'self' CSP directive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build asset configuration. Modified how assets are processed during builds to change inlining behavior. Assets will now be served as individual files rather than embedded, potentially affecting asset delivery and caching efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->